### PR TITLE
Fixing an issue to do with validating the token when there is a query string present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tmp
 *.so
 *.o
 *.a
+.idea
 mkmf.log
 
 s3.yml

--- a/lib/refile/version.rb
+++ b/lib/refile/version.rb
@@ -1,3 +1,3 @@
 module Refile
-  VERSION = "0.6.2"
+  VERSION = "0.6.21"
 end


### PR DESCRIPTION
Due to frontend gem changes we sometimes get requests with a timestamp query string param, and that stops refile from validating the token correctly which means we can't upload images in the legacy brand app.

This fixes the issue by removing the query string before validating that the image path is valid.